### PR TITLE
Sort all frames in the demo video

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -107,6 +107,7 @@ def main():
     video_name = 'video.avi'
 
     images = [img for img in os.listdir(image_folder) if img.endswith(".png")]
+    images.sort()
     frame = cv2.imread(os.path.join(image_folder, images[0]))
     height, width, layers = frame.shape
 


### PR DESCRIPTION
os.listdir does not guarantee the order of the file names returned.
Hence the frames in the video may not come out in order.
This patch sorts the frames in order of the file names so the demo
video come out correct.