### PR TITLE
Fixed sorting bug which sorts based on ASCII value of string rather than the integer value.

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -108,7 +108,7 @@ def main():
     video_name = 'video.avi'
 
     images = [img for img in os.listdir(image_folder) if img.endswith(".png")]
-    images.sort()
+    images.sort(key=lambda img_name: int(img_name.split('.')[0][4:]))
     frame = cv2.imread(os.path.join(image_folder, images[0]))
     height, width, layers = frame.shape
 


### PR DESCRIPTION
This PR addresses issue when there are more than 100 images saved. The python `sort()` call sorts strings according to their ASCII value so an example string "file100.png" would be before "file11.png". This will cause the video generated after sorting to be discontinuous. In this PR, sorting is performed according to the integer value in the string by stripping the string of "file" and ".png" and then perform sorting based on the integer value. The code snippet below further explains this -

```
name_list = ['file00.png', 'file01.png', 'file02.png', 'file03.png', 'file04.png', 'file05.png', 'file06.png', 'file07.png', 'file08.png', 'file09.png', 'file10.png', 'file11.png', 'file100.png']
print('Original list - ', name_list)
print("\n")

name_list.sort()
print('List after basic sort call - ', name_list)
print("\n")

name_list = ['file00.png', 'file01.png', 'file02.png', 'file03.png', 'file04.png', 'file05.png', 'file06.png', 'file07.png', 'file08.png', 'file09.png', 'file10.png', 'file11.png', 'file100.png']
print('Original list - ', name_list)
print("\n")

name_list.sort(key=lambda img_name: int(img_name.split('.')[0][4:]))
print('List after sorting by integer value in file name - ', name_list)
```

Generated output by above snippet - 
```
Original list -  ['file00.png', 'file01.png', 'file02.png', 'file03.png', 'file04.png', 'file05.png', 'file06.png', 'file07.png', 'file08.png', 'file09.png', 'file10.png', 'file11.png', 'file100.png']


List after basic sort call -  ['file00.png', 'file01.png', 'file02.png', 'file03.png', 'file04.png', 'file05.png', 'file06.png', 'file07.png', 'file08.png', 'file09.png', 'file10.png', 'file100.png', 'file11.png']


Original list -  ['file00.png', 'file01.png', 'file02.png', 'file03.png', 'file04.png', 'file05.png', 'file06.png', 'file07.png', 'file08.png', 'file09.png', 'file10.png', 'file11.png', 'file100.png']


List after sorting by integer value in file name -  ['file00.png', 'file01.png', 'file02.png', 'file03.png', 'file04.png', 'file05.png', 'file06.png', 'file07.png', 'file08.png', 'file09.png', 'file10.png', 'file11.png', 'file100.png']

```

As you can see, now string "file11.png" appears before "file100.png".