### PR TITLE
fix bug in two_stage_pp, reduce training memory

### DIFF
--- a/det3d/models/utils/finetune_utils.py
+++ b/det3d/models/utils/finetune_utils.py
@@ -93,7 +93,7 @@ class FrozenBatchNorm2d(nn.Module):
         https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/batchnorm.py
         """
         bn_module = nn.modules.batchnorm
-        bn_module = (bn_module.BatchNorm2d, bn_module.SyncBatchNorm)
+        bn_module = (bn_module.BatchNorm1d, bn_module.BatchNorm2d, bn_module.SyncBatchNorm)
         res = module
         if isinstance(module, bn_module):
             res = cls(module.num_features)

--- a/det3d/torchie/trainer/checkpoint.py
+++ b/det3d/torchie/trainer/checkpoint.py
@@ -163,7 +163,7 @@ def get_torchvision_models():
     return model_urls
 
 
-def load_checkpoint(model, filename, map_location=None, strict=False, logger=None):
+def load_checkpoint(model, filename, map_location='cpu', strict=False, logger=None):
     """Load checkpoint from a file or URI.
 
     Args:


### PR DESCRIPTION
Hello Tianwei,

Since BatchNorm1d exists on the reader of the PointPillars. In the two-stage training of CenterPoint-Pillars, BatchNorm1d should also be converted to FrozenBatchNorm, otherwise it will keep updating.

Moreover, I find a minor issue that causes inconsistent memory usage in distributed training of the two-stage. GPU 0 will occupy 600MB memory more.  It seems that the code will load the pretrained model on GPU as default. So loading it on CPU as default will save more memory on GPU 0. 
