### PR TITLE
Update config file to fix the bug when running on test set

### DIFF
--- a/configs/waymo/voxelnet/waymo_centerpoint_voxelnet_two_sweeps_3x_with_velo.py
+++ b/configs/waymo/voxelnet/waymo_centerpoint_voxelnet_two_sweeps_3x_with_velo.py
@@ -142,7 +142,7 @@ test_pipeline = [
 
 train_anno = "data/Waymo/infos_train_02sweeps_filter_zero_gt.pkl"
 val_anno = "data/Waymo/infos_val_02sweeps_filter_zero_gt.pkl"
-test_anno = None
+test_anno = "data/Waymo/infos_test_02sweeps_filter_zero_gt.pkl"
 
 data = dict(
     samples_per_gpu=4,


### PR DESCRIPTION
Hi,

The original `None` parameter set in the `waymo_centerpoint_voxelnet_two_sweeps_3x_with_velo.py` config file will cause error when running on the test set like this:

```
Traceback (most recent call last):
  File "tools/dist_test.py", line 211, in <module>
    main()
  File "tools/dist_test.py", line 110, in main
    dataset = build_dataset(cfg.data.test)
  File "/home/justin/Documents/CenterPoint/det3d/datasets/builder.py", line 42, in build_dataset
    dataset = build_from_cfg(cfg, DATASETS, default_args)
  File "/home/justin/Documents/CenterPoint/det3d/utils/registry.py", line 78, in build_from_cfg
    return obj_cls(**args)
  File "/home/justin/Documents/CenterPoint/det3d/datasets/waymo/waymo.py", line 40, in __init__
    root_path, info_path, pipeline, test_mode=test_mode, class_names=class_names
  File "/home/justin/Documents/CenterPoint/det3d/datasets/custom.py", line 37, in __init__
    self._set_group_flag()
  File "/home/justin/Documents/CenterPoint/det3d/datasets/custom.py", line 164, in _set_group_flag
    self.flag = np.ones(len(self), dtype=np.uint8)
  File "/home/justin/Documents/CenterPoint/det3d/datasets/waymo/waymo.py", line 61, in __len__
    self.load_infos(self._info_path)
  File "/home/justin/Documents/CenterPoint/det3d/datasets/waymo/waymo.py", line 51, in load_infos
    with open(self._info_path, "rb") as f:
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

Fixed this bug by assigning the correct path to the `test_anno`.

```python
# Original
test_anno = None

# to ...
test_anno = "data/Waymo/infos_test_02sweeps_filter_zero_gt.pkl"
```